### PR TITLE
strict types + new repository

### DIFF
--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebauthnEmulator;
 
 use CBOR\ByteStringObject;
@@ -131,7 +133,7 @@ class Authenticator implements AuthenticatorInterface
             }
         } else {
             try {
-                return $this->repository->getById($rpId, null);
+                return $this->repository->getById($rpId, '');
             } catch (CredentialNotFoundException) {
                 // nothing found, normal case
             }

--- a/src/AuthenticatorInterface.php
+++ b/src/AuthenticatorInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebauthnEmulator;
 
 use WebauthnEmulator\CredentialRepository\RepositoryInterface;

--- a/src/Credential.php
+++ b/src/Credential.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebauthnEmulator;
 
 use CBOR\ByteStringObject;

--- a/src/CredentialFactory.php
+++ b/src/CredentialFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebauthnEmulator;
 
 use WebauthnEmulator\Exceptions\InvalidArgumentException;

--- a/src/CredentialInterface.php
+++ b/src/CredentialInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebauthnEmulator;
 
 use JetBrains\PhpStorm\ArrayShape;

--- a/src/CredentialRepository/FileRepository.php
+++ b/src/CredentialRepository/FileRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebauthnEmulator\CredentialRepository;
 
 use RuntimeException;

--- a/src/CredentialRepository/InMemoryRepository.php
+++ b/src/CredentialRepository/InMemoryRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace WebauthnEmulator\CredentialRepository;
+
+use WebauthnEmulator\CredentialInterface;
+use WebauthnEmulator\Exceptions\CredentialNotFoundException;
+
+class InMemoryRepository implements RepositoryInterface
+{
+    private array $credentials = [];
+
+    public function save(CredentialInterface $credential): static
+    {
+        $this->credentials[$credential->getRpId()][$credential->getId()] = $credential;
+
+        return $this;
+    }
+
+    public function get(string $rpId): array
+    {
+        return $this->credentials[$rpId] ?? [];
+    }
+
+    public function getById(string $rpId, string $id): CredentialInterface
+    {
+        $credential = $this->credentials[$rpId][$id] ?? null;
+        if ($credential === null) {
+            throw new CredentialNotFoundException('credential not found');
+        }
+
+        return $credential;
+    }
+}

--- a/src/CredentialRepository/RepositoryInterface.php
+++ b/src/CredentialRepository/RepositoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebauthnEmulator\CredentialRepository;
 
 use WebauthnEmulator\CredentialInterface;

--- a/src/Exceptions/CredentialNotFoundException.php
+++ b/src/Exceptions/CredentialNotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebauthnEmulator\Exceptions;
 
 class CredentialNotFoundException extends WebauthnEmulatorException

--- a/src/Exceptions/InvalidArgumentException.php
+++ b/src/Exceptions/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebauthnEmulator\Exceptions;
 
 class InvalidArgumentException extends WebauthnEmulatorException

--- a/src/Exceptions/WebauthnEmulatorException.php
+++ b/src/Exceptions/WebauthnEmulatorException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WebauthnEmulator\Exceptions;
 
 use RuntimeException;


### PR DESCRIPTION
Hi, 
I'm using php 8.4 with strict types everywhere and when calling
```php
$assertion = $authenticator->getAssertion(
            $publicKeyCredentialRequestOptions->rpId,
            null,
            $publicKeyCredentialRequestOptions->challenge,
        );
```

I get this error:
```
TypeError: WebauthnEmulator\CredentialRepository\FileRepository::getById(): Argument #2 ($id) must be of type string, null given, called in /var/www/html/vendor/pronin/webauthn-emulator/src/Authenticator.php on line 134
```
This is fixed by 29cb41f13fd6bd93c071d9973d2abb71e5b30b3b. It works when not declaring strict types on php <8 as it's coerced to "".

---
Then I added strict types everywhere and also created InMemoryRepository class, which is similar to FileRepository, but does not use filesystem, it holds everything in private variable. This works better in my case as I'm using this library for phpunit only. I think that might be useful to someone else. 

I was not checking the examples as I'm not sure if they're really executable.
